### PR TITLE
Better Postgres support

### DIFF
--- a/sqeleton/databases/base.py
+++ b/sqeleton/databases/base.py
@@ -539,6 +539,7 @@ class ThreadedDatabase(Database):
 
     Used for database connectors that do not support sharing their connection between different threads.
     """
+    query_timeout = None
 
     def __init__(self, thread_count=1):
         self._init_error = None
@@ -574,6 +575,9 @@ class ThreadedDatabase(Database):
     @property
     def is_autocommit(self) -> bool:
         return False
+    
+    def set_query_timeout(self, timeout: int) -> None:
+        logging.warn('Query timeout is not yet supported for this DB')
 
 
 CHECKSUM_HEXDIGITS = 15  # Must be 15 or lower, otherwise SUM() overflows

--- a/sqeleton/databases/postgresql.py
+++ b/sqeleton/databases/postgresql.py
@@ -97,6 +97,9 @@ class PostgresqlDialect(BaseDialect, Mixin_Schema):
 
     def current_timestamp(self) -> str:
         return "current_timestamp"
+    
+    def set_timeout(self, timeout: int) -> str:
+        return f"SET statement_timeout = {timeout * 1000}"
 
 
 class PostgreSQL(ThreadedDatabase):
@@ -161,3 +164,8 @@ class PostgreSQL(ThreadedDatabase):
         raise ValueError(
             f"{self.name}: Bad table path for {self}: '{'.'.join(path)}'. Expected format: table, schema.table, or database.schema.table"
         )
+
+    def set_query_timeout(self, timeout: int) -> None:
+        if self.query_timeout != timeout:
+            self.query_timeout = timeout
+            self.query(self.dialect.set_timeout(self.query_timeout))

--- a/sqeleton/databases/postgresql.py
+++ b/sqeleton/databases/postgresql.py
@@ -120,6 +120,9 @@ class PostgresqlDialect(BaseDialect, Mixin_Schema):
 
         return super().parse_type(table_path, col_name, type_repr, datetime_precision, numeric_precision)
     
+    def concat_with_sep(self, items: List[str], sep: str) -> str:
+        return f"concat_ws('{sep}', {', '.join(items)})"
+
 
 class PostgreSQL(ThreadedDatabase):
     dialect = PostgresqlDialect()

--- a/sqeleton/databases/redshift.py
+++ b/sqeleton/databases/redshift.py
@@ -1,5 +1,7 @@
 import logging
 from typing import List, Dict
+
+from sqeleton.utils import join_iter
 from ..abcs.database_types import Float, TemporalType, FractionalType, DbPath
 from ..abcs.mixins import AbstractMixin_MD5
 from .postgresql import (
@@ -60,6 +62,10 @@ class Dialect(PostgresqlDialect):
     def concat(self, items: List[str]) -> str:
         joined_exprs = " || ".join(items)
         return f"({joined_exprs})"
+    
+    def concat_with_sep(self, items: List[str], sep: str) -> str:
+        items = list(join_iter(f"'{sep}'", items))
+        return self.concat(items)
 
     def is_distinct_from(self, a: str, b: str) -> str:
         return f"({a} IS NULL != {b} IS NULL) OR ({a}!={b})"

--- a/sqeleton/queries/ast_classes.py
+++ b/sqeleton/queries/ast_classes.py
@@ -183,7 +183,9 @@ class Concat(ExprNode):
         if len(items) == 1:
             return items[0]
 
-        if self.sep:
+        if self.sep and hasattr(c.dialect, "concat_with_sep"):
+            return c.dialect.concat_with_sep(items, self.sep)
+        elif self.sep:
             items = list(join_iter(f"'{self.sep}'", items))
         return c.dialect.concat(items)
 


### PR DESCRIPTION
Support db-mediated query timeout in Postgres
- useful because data-diff relies heavily on multi-threading to run queries, and threads can't easily be killed by the parent
Support parsing character varying w/ length (postgres)
- Previously columns of type "character varying(4)" would error out (eg)
Add support for up to 99 columns in Postgres
- Previously only 50 columns were possible to include for PG databases